### PR TITLE
Drop mainlogger instance to release background resources

### DIFF
--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -49,4 +49,9 @@ MainLogger::~MainLogger()
 {
 	spdlog::info("Goodbye!");
 	_mainLogger->flush();
+	spdlog::drop(_mainLogger->name());
+
+	// Set default logger
+	spdlog::set_default_logger(
+		std::make_shared<spdlog::logger>("default", std::make_shared<spdlog::sinks::stdout_color_sink_mt>()));
 }


### PR DESCRIPTION
This PR fixes the issue causes background worker threads are not releasing because of the spdlog logger not resetted.